### PR TITLE
add autosearch feature

### DIFF
--- a/html/using.html
+++ b/html/using.html
@@ -174,6 +174,11 @@ current value, <code>/set bitlbee_server bitlbee_tag</code> will set it to
        dates in timestamps.</li>
   <li><code>twitter_search_results</code> - Default: 5.  How many results to
        show for the initial search.</li>
+  <li><code>twitter_autosearch_results</code> - How many results should be displayed
+       for autosearches.  An autosearch is an automatic search for every hashtag that
+       you have written in a /tweet.  Think of it as &quot;tell me what others have
+       recently written on my topics&quot;.  Default is 0 which deactivates the
+       autosearch feature.</li>
   <li><code>retweet_show</code> - Default: Off.  When set to On, you will see
        your own (non-classic) retweets in your timeline.</li>
   <li><code>retweet_classic</code> - Default: Off.  When set to On, a retweet

--- a/twirssi.pl
+++ b/twirssi.pl
@@ -119,6 +119,7 @@ my @settings_defn = (
         [ 'poll_interval',     'twitter_poll_interval',     'i', 300 ],
         [ 'poll_schedule',     'twitter_poll_schedule',     's', '',			'list{,}' ],
         [ 'search_results',    'twitter_search_results',    'i', 5 ],
+        [ 'autosearch_results','twitter_autosearch_results','i', 0 ],
         [ 'timeout',           'twitter_timeout',           'i', 30 ],
         [ 'track_replies',     'twirssi_track_replies',     'i', 100 ],
 );
@@ -426,6 +427,19 @@ sub cmd_tweet_as {
 
     foreach ( $data =~ /@([-\w]+)/g ) {
         $nicks{$_} = time;
+    }
+
+    # TODO: What's the official definition of a Hashtag? Let's use #[-\w]+ like above for now.
+    if ( $settings{autosearch_results} > 0 and $data =~ /#[-\w]+/ ) {
+	my @topics;
+	while ( $data =~ /(#[-\w]+)/g ) {
+	    push @topics, $1;
+	    $search_once{$username}->{$1} = $settings{autosearch_results};
+	}
+	&get_updates([ 0, [
+			   [ $username, { up_searches => [ @topics ] } ],
+		       ],
+		     ]);
     }
 
     $state{__last_id}{$username}{__sent} = $res->{id};


### PR DESCRIPTION
This will start a search for every hashtag that you've tweeted.
Think of it as "See what other people have recently said on your topics".

/set twitter_autosearch_results to > 0 to activate.
