### PR TITLE
Fixing issue 38

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,7 @@ In a terminal:
     * Remove any old version of the script: rm twirssi.pl
     * Download the latest version: wget http://twirssi.com/twirssi.pl
     * If you want it to automatically load with irssi, create an autorun dir: mkdir autorun
+    * Change to that directory: cd autorun
     * And create a symlink in it: ln -s ../twirssi.pl autorun
 
 In irssi:


### PR DESCRIPTION
https://github.com/zigdon/twirssi/issues/38

The readme seems to have some issue. I think either a cd to the autorun directory is needed or the link command is referring to the twirssi.pl where we were not told to put it. Sorry if I misunderstand, but I think there is a consistency issue here.

```
* If you want it to automatically load with irssi, create an autorun dir: mkdir autorun
* And create a symlink in it: ln -s ../twirssi.pl autorun
```

I added direction to a bullet instructing user to cd to autorun.
