### PR TITLE
adds in setting for unshorten urls color

### DIFF
--- a/html/using.html
+++ b/html/using.html
@@ -149,6 +149,10 @@ current value, <code>/set bitlbee_server bitlbee_tag</code> will set it to
       color set. (default: %B).  Note that the theme variables (twirssi_tweet,
       twirssi_search, twirssi_reply, twirssi_dm) should be updated as
       well.</li>
+  <li><code>twirssi_hilight_color</code> - Color that hilights should be for
+      the twirssi window. (default %M)</li>
+  <li><code>twirssi_unshorten_color</code> - Color for unshortned URL links
+      will display as, when enabled. (default %b)</li>
   <li><code>twirssi_replies_autonick</code> - On by default.  If on, /reply
       will make sure the reply begins with @nick.  If off, you can reply to
       someone, but not have their name on the reply</li>

--- a/twirssi.pl
+++ b/twirssi.pl
@@ -26,7 +26,7 @@ $VERSION = sprintf '%s', q$Version: v2.5.1beta136$ =~ /^\w+:\s+v(\S+)/;
       . 'Can optionally set your bitlbee /away message to same',
     license => 'GNU GPL v2',
     url     => 'http://twirssi.com',
-    changed => '$Date: 2011-10-15 21:56:48 +0000$',
+    changed => '$Date: 2011-10-21 13:55:11 +0000$',
 );
 
 my $twit;	# $twit is current logged-in Net::Twitter object (usually one of %twits)


### PR DESCRIPTION
For the unshorten url functionality, the colour was hard coded in as %b, which may not be the color you want. (I know i didn't :-)).

This changeset adds this in, as well as documentation for it; and documentation for twirssi_hilight_color as it was missing to
