### PR TITLE
Allow DMs  to be 10k chars long (see link)

### DIFF
--- a/twirssi.pl
+++ b/twirssi.pl
@@ -3044,7 +3044,14 @@ sub too_long {
     my $data     = shift;
     my $alert_to = shift;
 
-    if ( length $data > 140 ) {
+    my $max_len = 140;
+    if($alert_to && $alert_to->[0] eq 'dm') {
+        # Twitter removed (more or less) the DM limit:
+        # https://blog.twitter.com/official/en_us/a/2015/removing-the-140-character-limit-from-direct-messages.html
+        $max_len = 10000;
+    }
+
+    if ( length $data > $max_len ) {
         &notice( $alert_to,
             "Tweet too long (" . length($data) . " characters) - aborted" )
           if defined $alert_to;


### PR DESCRIPTION
Twitter allowed DMs to be 10k chars long a couple of years ago, this amends the code to default to 140 chars, but use 10k chars when sending a DM.
